### PR TITLE
SIGPEX-44163 Depend on newer version of parking_lot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ once_cell = "^1.2"
 #backtrace = "=0.3"
 typed-arena = "^2.0"
 better_any = "=0.1"
-parking_lot = "0.11"
+parking_lot = "0.12"
 #qcell = { path="../qcell" }
 
 [lib]


### PR DESCRIPTION
The current version of parking_lot depends on the unmaintained crate "instant". [1]

[1] https://rustsec.org/advisories/RUSTSEC-2024-0384.html